### PR TITLE
feat(#3): Add footnote parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Add this package wherever you use `mdformat` and the plugin will be auto-recogni
 - [mdformat-beautysh](https://pypi.org/project/mdformat-beautysh)
 - [mdformat-black](https://pypi.org/project/mdformat-black)
 - [mdformat-config](https://pypi.org/project/mdformat-config)
-- [mdformat-footnote](https://pypi.org/project/mdformat-footnote)
 - [mdformat-frontmatter](https://pypi.org/project/mdformat-frontmatter)
 - [mdformat-simple-breaks](https://pypi.org/project/mdformat-simple-breaks)
 - [mdformat-tables](https://pypi.org/project/mdformat-tables)

--- a/mdformat_obsidian/factories/_obsidian_blockquote_factories.py
+++ b/mdformat_obsidian/factories/_obsidian_blockquote_factories.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Callable, NamedTuple
 
 from markdown_it import MarkdownIt
 from markdown_it.rules_block import StateBlock
+from markdown_it.rules_inline import StateInline
 from mdit_py_plugins.utils import is_code_block
 
 if TYPE_CHECKING:
@@ -22,8 +23,12 @@ if TYPE_CHECKING:
 
 # FYI: copied from mdformat_admon.factories
 @contextmanager
-def new_token(state: StateBlock, name: str, kind: str) -> Generator[Token, None, None]:
-    """Return scoped token."""
+def new_token(
+    state: StateBlock | StateInline,
+    name: str,
+    kind: str,
+) -> Generator[Token, None, None]:
+    """Create scoped token."""
     yield state.push(f"{name}_open", kind, 1)
     state.push(f"{name}_close", kind, -1)
 

--- a/mdformat_obsidian/mdit_plugins/__init__.py
+++ b/mdformat_obsidian/mdit_plugins/__init__.py
@@ -4,10 +4,18 @@ from ._obsidian_callouts import (
     format_obsidian_callout_markup,
     obsidian_callout_plugin,
 )
+from ._obsidian_inline_footnotes import (
+    OBSIDIAN_INLINE_FOOTNOTE_PREFIX,
+    # format_obsidian_inline_footnote_markup,
+    obsidian_inline_footnote_plugin,
+)
 
 __all__ = (
     "INLINE_SEP",
     "OBSIDIAN_CALLOUT_PREFIX",
+    "OBSIDIAN_INLINE_FOOTNOTE_PREFIX",
     "format_obsidian_callout_markup",
+    # "format_obsidian_inline_footnote_markup",
     "obsidian_callout_plugin",
+    "obsidian_inline_footnote_plugin",
 )

--- a/mdformat_obsidian/mdit_plugins/__init__.py
+++ b/mdformat_obsidian/mdit_plugins/__init__.py
@@ -1,3 +1,5 @@
+from mdit_py_plugins.footnote import footnote_plugin
+
 from ._obsidian_callouts import (
     INLINE_SEP,
     OBSIDIAN_CALLOUT_PREFIX,
@@ -5,17 +7,18 @@ from ._obsidian_callouts import (
     obsidian_callout_plugin,
 )
 from ._obsidian_inline_footnotes import (
-    OBSIDIAN_INLINE_FOOTNOTE_PREFIX,
-    format_obsidian_inline_footnote_markup,
-    obsidian_inline_footnote_plugin,
+    format_footnote,
+    format_footnote_block,
+    format_footnote_ref,
 )
 
 __all__ = (
     "INLINE_SEP",
     "OBSIDIAN_CALLOUT_PREFIX",
-    "OBSIDIAN_INLINE_FOOTNOTE_PREFIX",
+    "footnote_plugin",
+    "format_footnote",
+    "format_footnote_block",
+    "format_footnote_ref",
     "format_obsidian_callout_markup",
-    "format_obsidian_inline_footnote_markup",
     "obsidian_callout_plugin",
-    "obsidian_inline_footnote_plugin",
 )

--- a/mdformat_obsidian/mdit_plugins/__init__.py
+++ b/mdformat_obsidian/mdit_plugins/__init__.py
@@ -6,7 +6,7 @@ from ._obsidian_callouts import (
 )
 from ._obsidian_inline_footnotes import (
     OBSIDIAN_INLINE_FOOTNOTE_PREFIX,
-    # format_obsidian_inline_footnote_markup,
+    format_obsidian_inline_footnote_markup,
     obsidian_inline_footnote_plugin,
 )
 
@@ -15,7 +15,7 @@ __all__ = (
     "OBSIDIAN_CALLOUT_PREFIX",
     "OBSIDIAN_INLINE_FOOTNOTE_PREFIX",
     "format_obsidian_callout_markup",
-    # "format_obsidian_inline_footnote_markup",
+    "format_obsidian_inline_footnote_markup",
     "obsidian_callout_plugin",
     "obsidian_inline_footnote_plugin",
 )

--- a/mdformat_obsidian/mdit_plugins/_obsidian_callouts.py
+++ b/mdformat_obsidian/mdit_plugins/_obsidian_callouts.py
@@ -15,7 +15,7 @@ OBSIDIAN_CALLOUT_PREFIX = "obsidian_callout"
 """Prefix used to differentiate the parsed output."""
 
 INLINE_SEP = "\n\n"
-"""Optional separator to differentiate the title and ineline content (if present)."""
+"""Optional separator to differentiate the title and, if present, inline content."""
 
 PATTERN = r"^\\?\[!(?P<title>[^\]]+)\\?\](?P<fold>[\-\+]?)"
 """Regular expression to match Obsidian Alerts."""

--- a/mdformat_obsidian/mdit_plugins/_obsidian_inline_footnotes.py
+++ b/mdformat_obsidian/mdit_plugins/_obsidian_inline_footnotes.py
@@ -10,6 +10,7 @@ import re
 
 from markdown_it import MarkdownIt
 from markdown_it.rules_inline import StateInline
+from mdformat.renderer import RenderContext, RenderTreeNode
 
 from mdformat_obsidian.factories import new_token
 
@@ -18,6 +19,14 @@ OBSIDIAN_INLINE_FOOTNOTE_PREFIX = "obsidian_inline_footnote"
 
 _PATTERN = re.compile(r"(?<= )\^\\?\[(?P<footnote>[^\]]+)\\?\]")
 """Regular expression to match inline footnotes."""
+
+
+def format_obsidian_inline_footnote_markup(
+    node: RenderTreeNode,
+    _context: RenderContext,
+) -> str:
+    """Format inline footnotes."""
+    return f'^[{node.meta["inline_footnote"]}]'
 
 
 def _inline_footnote(state: StateInline, silent: bool) -> bool:
@@ -29,12 +38,10 @@ def _inline_footnote(state: StateInline, silent: bool) -> bool:
     if silent:
         return True
 
-    pos = state.pos
     state.pos = match.start()
-    with new_token(state, OBSIDIAN_INLINE_FOOTNOTE_PREFIX, "a") as token:
-        token.meta = {"content": f'^[{match["footnote"]}]'}
+    with new_token(state, OBSIDIAN_INLINE_FOOTNOTE_PREFIX, "") as token:
+        token.meta = {"inline_footnote": match["footnote"]}
 
-    state.pos = pos
     state.pos += match.end()
 
     return True

--- a/mdformat_obsidian/mdit_plugins/_obsidian_inline_footnotes.py
+++ b/mdformat_obsidian/mdit_plugins/_obsidian_inline_footnotes.py
@@ -2,55 +2,53 @@
 
 Docs: https://help.obsidian.md/Editing+and+formatting/Basic+formatting+syntax#Footnotes
 
+TODO: Add rendering support to mdformat-footnote:
+https://github.com/executablebooks/mdformat-footnote/blob/80852fc20cfba7fd0330b9ac7a1a4df983542942/mdformat_footnote/plugin.py#L17
+
+HACK: Under MIT license, code is adapted from:
+https://github.com/executablebooks/mdformat-footnote/blob/80852fc20cfba7fd0330b9ac7a1a4df983542942/mdformat_footnote/plugin.py#L19C1-L51
+
 """
 
 from __future__ import annotations
 
-import re
+import textwrap
+from contextlib import suppress
 
-from markdown_it import MarkdownIt
-from markdown_it.rules_inline import StateInline
 from mdformat.renderer import RenderContext, RenderTreeNode
 
-from mdformat_obsidian.factories import new_token
 
-OBSIDIAN_INLINE_FOOTNOTE_PREFIX = "obsidian_inline_footnote"
-"""Prefix used to differentiate the parsed output."""
+def format_footnote(node: RenderTreeNode, context: RenderContext) -> str:
+    """Extend footnote formatting to exclude inline."""
+    if not node.meta["label"]:
+        return ""
 
-_PATTERN = re.compile(r"(?<= )\^\\?\[(?P<footnote>[^\]]+)\\?\]")
-"""Regular expression to match inline footnotes."""
-
-
-def format_obsidian_inline_footnote_markup(
-    node: RenderTreeNode,
-    _context: RenderContext,
-) -> str:
-    """Format inline footnotes."""
-    return f'^[{node.meta["inline_footnote"]}]'
-
-
-def _inline_footnote(state: StateInline, silent: bool) -> bool:
-    """Identify inline footnotes."""
-    match = _PATTERN.search(state.src[state.pos : state.posMax])
-    if not match:
-        return False
-
-    if silent:
-        return True
-
-    state.pos = match.start()
-    with new_token(state, OBSIDIAN_INLINE_FOOTNOTE_PREFIX, "") as token:
-        token.meta = {"inline_footnote": match["footnote"]}
-
-    state.pos += match.end()
-
-    return True
+    first_line = f"[^{node.meta['label']}]:"
+    indent = " " * 4
+    elements = []
+    with context.indented(len(indent)):
+        for child in node.children:
+            if child.type == "footnote_anchor":
+                continue
+            elements.append(child.render(context))
+    body = textwrap.indent("\n\n".join(elements), indent)
+    # if the first body element is a paragraph, we can start on the first line,
+    # otherwise we start on the second line
+    if body and node.children and node.children[0].type != "paragraph":
+        body = "\n" + body
+    else:
+        body = " " + body.lstrip()
+    return first_line + body
 
 
-def obsidian_inline_footnote_plugin(md: MarkdownIt) -> None:
-    md.inline.ruler.before(
-        "text",
-        OBSIDIAN_INLINE_FOOTNOTE_PREFIX,
-        _inline_footnote,
-        {"alt": ["text"]},
-    )
+def format_footnote_ref(node: RenderTreeNode, context: RenderContext) -> str:
+    """Extend footnote refs to support inline footnote formatting."""
+    with suppress(KeyError):
+        return f"[^{node.meta['label']}]"
+    # Locate footnote content by id
+    content = context.env["footnotes"]["list"][node.meta["id"]]["content"]
+    return f"^[{content}]"
+
+
+def format_footnote_block(node: RenderTreeNode, context: RenderContext) -> str:
+    return "\n\n".join(child.render(context) for child in node.children)

--- a/mdformat_obsidian/mdit_plugins/_obsidian_inline_footnotes.py
+++ b/mdformat_obsidian/mdit_plugins/_obsidian_inline_footnotes.py
@@ -1,0 +1,65 @@
+"""Obsidian Inline Footnotes.
+
+Docs: https://help.obsidian.md/Editing+and+formatting/Basic+formatting+syntax#Footnotes
+
+"""
+
+from __future__ import annotations
+
+import re
+
+from markdown_it import MarkdownIt
+from markdown_it.rules_block import StateBlock
+from mdit_py_plugins.utils import is_code_block
+
+from mdformat_obsidian.factories import new_token
+
+OBSIDIAN_INLINE_FOOTNOTE_PREFIX = "obsidian_inline_footnote"
+"""Prefix used to differentiate the parsed output."""
+
+_PATTERN = re.compile(r"^(?P<other>.+) \^\\?\[(?P<footnote>[^\]]+)\\?\]")
+"""Regular expression to match inline footnotes."""
+
+
+def _new_match(state: StateBlock, start_line: int) -> re.Match[str] | None:
+    """Determine match between start and end lines."""
+    start = state.bMarks[start_line] + state.tShift[start_line]
+    maximum = state.eMarks[start_line]
+    return _PATTERN.match(state.src[start:maximum])
+
+
+def _inline_footnote(
+    state: StateBlock,
+    start_line: int,
+    end_line: int,
+    silent: bool,
+) -> bool:
+    """Identify inline footnotes."""
+    if is_code_block(state, start_line):
+        return False
+
+    match = _new_match(state, start_line)
+    if match is None:
+        return False
+
+    if silent:
+        return True
+
+    with new_token(state, OBSIDIAN_INLINE_FOOTNOTE_PREFIX, "p"):
+        tkn_inline = state.push("inline", "", 0)
+        tkn_inline.content = f'{match["other"]} ^[{match["footnote"]}]'
+        tkn_inline.map = [start_line, end_line]
+        tkn_inline.children = []
+
+    state.line = end_line + 1
+
+    return True
+
+
+def obsidian_inline_footnote_plugin(md: MarkdownIt) -> None:
+    md.block.ruler.before(
+        "paragraph",
+        OBSIDIAN_INLINE_FOOTNOTE_PREFIX,
+        _inline_footnote,
+        {"alt": ["paragraph"]},
+    )

--- a/mdformat_obsidian/plugin.py
+++ b/mdformat_obsidian/plugin.py
@@ -8,12 +8,19 @@ from markdown_it import MarkdownIt
 from mdformat.renderer import RenderContext, RenderTreeNode
 from mdformat.renderer.typing import Render
 
-from .mdit_plugins import INLINE_SEP, OBSIDIAN_CALLOUT_PREFIX, obsidian_callout_plugin
+from .mdit_plugins import (
+    INLINE_SEP,
+    OBSIDIAN_CALLOUT_PREFIX,
+    OBSIDIAN_INLINE_FOOTNOTE_PREFIX,
+    obsidian_callout_plugin,
+    obsidian_inline_footnote_plugin,
+)
 
 
 def update_mdit(mdit: MarkdownIt) -> None:
     """Update the parser to identify Alerts."""
     mdit.use(obsidian_callout_plugin)
+    mdit.use(obsidian_inline_footnote_plugin)
 
 
 def _render_obsidian_callout(node: RenderTreeNode, context: RenderContext) -> str:
@@ -30,6 +37,15 @@ def _no_render(
 ) -> str:
     """Skip rendering when handled separately."""
     return ""
+
+
+def _render_content(
+    node: RenderTreeNode,
+    context: RenderContext,  # noqa: ARG001
+) -> str:
+    """Render content."""
+    elements = [child.content for child in node.children if child.content]
+    return "\n\n".join(elements).rstrip()
 
 
 def _recursive_render(
@@ -51,4 +67,5 @@ RENDERERS: Mapping[str, Render] = {
     f"{OBSIDIAN_CALLOUT_PREFIX}_collapsed": _no_render,
     # FIXME: can I add divs without introducing new blocks?
     f"{OBSIDIAN_CALLOUT_PREFIX}_content": _recursive_render,
+    OBSIDIAN_INLINE_FOOTNOTE_PREFIX: _render_content,
 }

--- a/mdformat_obsidian/plugin.py
+++ b/mdformat_obsidian/plugin.py
@@ -11,17 +11,18 @@ from mdformat.renderer.typing import Render
 from .mdit_plugins import (
     INLINE_SEP,
     OBSIDIAN_CALLOUT_PREFIX,
-    OBSIDIAN_INLINE_FOOTNOTE_PREFIX,
-    format_obsidian_inline_footnote_markup,
+    footnote_plugin,
+    format_footnote,
+    format_footnote_block,
+    format_footnote_ref,
     obsidian_callout_plugin,
-    obsidian_inline_footnote_plugin,
 )
 
 
 def update_mdit(mdit: MarkdownIt) -> None:
     """Update the parser to identify Alerts."""
     mdit.use(obsidian_callout_plugin)
-    mdit.use(obsidian_inline_footnote_plugin)
+    mdit.use(footnote_plugin)
 
 
 def _render_obsidian_callout(node: RenderTreeNode, context: RenderContext) -> str:
@@ -53,11 +54,13 @@ def _recursive_render(
 # This can be used to overwrite renderer functions of existing syntax
 # or add support for new syntax.
 RENDERERS: Mapping[str, Render] = {
+    "footnote": format_footnote,
+    "footnote_ref": format_footnote_ref,
+    "footnote_block": format_footnote_block,
     OBSIDIAN_CALLOUT_PREFIX: _render_obsidian_callout,
     f"{OBSIDIAN_CALLOUT_PREFIX}_title": _no_render,
     f"{OBSIDIAN_CALLOUT_PREFIX}_title_inner": _no_render,
     f"{OBSIDIAN_CALLOUT_PREFIX}_collapsed": _no_render,
     # FIXME: can I add divs without introducing new blocks?
     f"{OBSIDIAN_CALLOUT_PREFIX}_content": _recursive_render,
-    OBSIDIAN_INLINE_FOOTNOTE_PREFIX: format_obsidian_inline_footnote_markup,
 }

--- a/mdformat_obsidian/plugin.py
+++ b/mdformat_obsidian/plugin.py
@@ -39,13 +39,9 @@ def _no_render(
     return ""
 
 
-def _render_content(
-    node: RenderTreeNode,
-    context: RenderContext,  # noqa: ARG001
-) -> str:
-    """Render content."""
-    elements = [child.content for child in node.children if child.content]
-    return "\n\n".join(elements).rstrip()
+def _render_meta_content(node: RenderTreeNode, context: RenderContext) -> str:  # noqa: ARG001
+    """Return node content without additional processing."""
+    return node.meta.get("content", "")
 
 
 def _recursive_render(
@@ -67,5 +63,5 @@ RENDERERS: Mapping[str, Render] = {
     f"{OBSIDIAN_CALLOUT_PREFIX}_collapsed": _no_render,
     # FIXME: can I add divs without introducing new blocks?
     f"{OBSIDIAN_CALLOUT_PREFIX}_content": _recursive_render,
-    OBSIDIAN_INLINE_FOOTNOTE_PREFIX: _render_content,
+    OBSIDIAN_INLINE_FOOTNOTE_PREFIX: _render_meta_content,
 }

--- a/mdformat_obsidian/plugin.py
+++ b/mdformat_obsidian/plugin.py
@@ -12,6 +12,7 @@ from .mdit_plugins import (
     INLINE_SEP,
     OBSIDIAN_CALLOUT_PREFIX,
     OBSIDIAN_INLINE_FOOTNOTE_PREFIX,
+    format_obsidian_inline_footnote_markup,
     obsidian_callout_plugin,
     obsidian_inline_footnote_plugin,
 )
@@ -39,11 +40,6 @@ def _no_render(
     return ""
 
 
-def _render_meta_content(node: RenderTreeNode, context: RenderContext) -> str:  # noqa: ARG001
-    """Return node content without additional processing."""
-    return node.meta.get("content", "")
-
-
 def _recursive_render(
     node: RenderTreeNode,
     context: RenderContext,
@@ -63,5 +59,5 @@ RENDERERS: Mapping[str, Render] = {
     f"{OBSIDIAN_CALLOUT_PREFIX}_collapsed": _no_render,
     # FIXME: can I add divs without introducing new blocks?
     f"{OBSIDIAN_CALLOUT_PREFIX}_content": _recursive_render,
-    OBSIDIAN_INLINE_FOOTNOTE_PREFIX: _render_meta_content,
+    OBSIDIAN_INLINE_FOOTNOTE_PREFIX: format_obsidian_inline_footnote_markup,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
 ]
 dependencies = [
   "mdformat >= 0.7.17",
-  "mdformat-footnote >= 0.1.1",
   "mdformat-gfm >= 0.3.6",
   "mdit-py-plugins >= 0.4.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "mdformat >= 0.7.17",
+  "mdformat-footnote >= 0.1.1",
   "mdformat-gfm >= 0.3.6",
   "mdit-py-plugins >= 0.4.1",
 ]
@@ -32,7 +33,6 @@ recommended = [
   # Keep in-sync with README
   "mdformat-beautysh >= 0.1.1",
   "mdformat-config >= 0.1.3",
-  "mdformat-footnote >= 0.1.1",
   "mdformat-frontmatter >= 2.0.8",
   "mdformat-ruff >= 0.1.3",
   "mdformat-simple-breaks >= 0.0.1",

--- a/tests/format/fixtures/obsidian_inline_footnotes.md
+++ b/tests/format/fixtures/obsidian_inline_footnotes.md
@@ -1,0 +1,27 @@
+Inline Footnote (https://github.com/KyleKing/mdformat-obsidian/issues/3)
+.
+You can also use inline footnotes. ^[This is an inline footnote.]
+.
+You can also use inline footnotes. ^[This is an inline footnote.]
+.
+
+Full example (requires `mdformat_footnote` for proper formatting)
+.
+This is a simple footnote[^1].
+
+You can also use inline footnotes. ^[This is an inline footnote.]
+
+[^1]: This is the referenced text.
+[^2]: Add 2 spaces at the start of each new line.
+  This lets you write footnotes that span multiple lines.
+[^note]: Named footnotes still appear as numbers, but can make it easier to identify and link references.
+.
+This is a simple footnote[^1].
+
+You can also use inline footnotes. ^[This is an inline footnote.]
+
+[^1]: This is the referenced text.
+[^2]: Add 2 spaces at the start of each new line.
+  This lets you write footnotes that span multiple lines.
+[^note]: Named footnotes still appear as numbers, but can make it easier to identify and link references.
+.

--- a/tests/format/fixtures/obsidian_inline_footnotes.md
+++ b/tests/format/fixtures/obsidian_inline_footnotes.md
@@ -7,21 +7,20 @@ You can also use inline footnotes. ^[This is an inline footnote.]
 
 Full example (requires `mdformat_footnote` for proper formatting)
 .
-This is a simple footnote[^1].
+There are footnotes[^2][^note].
 
 You can also use inline footnotes. ^[This is an inline footnote.]
 
-[^1]: This is the referenced text.
 [^2]: Add 2 spaces at the start of each new line.
   This lets you write footnotes that span multiple lines.
 [^note]: Named footnotes still appear as numbers, but can make it easier to identify and link references.
 .
-This is a simple footnote[^1].
+There are footnotes[^2][^note].
 
 You can also use inline footnotes. ^[This is an inline footnote.]
 
-[^1]: This is the referenced text.
 [^2]: Add 2 spaces at the start of each new line.
-  This lets you write footnotes that span multiple lines.
+    This lets you write footnotes that span multiple lines.
+
 [^note]: Named footnotes still appear as numbers, but can make it easier to identify and link references.
 .

--- a/tests/format/test_format.py
+++ b/tests/format/test_format.py
@@ -31,6 +31,6 @@ fixtures = flatten(
     ids=[f[1] for f in fixtures],
 )
 def test_material_content_tabs_fixtures(line, title, text, expected):
-    output = mdformat.text(text, extensions={"footnote", "obsidian"})
+    output = mdformat.text(text, extensions={"obsidian"})
     print_text(output, expected)
     assert output.rstrip() == expected.rstrip()

--- a/tests/format/test_format.py
+++ b/tests/format/test_format.py
@@ -31,6 +31,6 @@ fixtures = flatten(
     ids=[f[1] for f in fixtures],
 )
 def test_material_content_tabs_fixtures(line, title, text, expected):
-    output = mdformat.text(text, extensions={"obsidian"})
+    output = mdformat.text(text, extensions={"footnote", "obsidian"})
     print_text(output, expected)
     assert output.rstrip() == expected.rstrip()

--- a/tests/format/test_format.py
+++ b/tests/format/test_format.py
@@ -20,7 +20,7 @@ def flatten(nested_list: list[list[T]]) -> list[T]:
 fixtures = flatten(
     [
         read_fixture_file(Path(__file__).parent / "fixtures" / fixture_path)
-        for fixture_path in ("obsidian_callouts.md",)
+        for fixture_path in ("obsidian_callouts.md", "obsidian_inline_footnotes.md")
     ],
 )
 


### PR DESCRIPTION
Fix: #3

Escaping brackets is a bigger issue with `mdformat` (https://github.com/executablebooks/mdformat/issues/112), but once done, this PR should identify inline footnotes and format them correctly, but without rendering

`mdformat-footnote` was removed because it does not handle inline footnotes properly