### PR TITLE
feat: replace blockquote with div in HTML output for accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,26 @@
 [cov-link]: https://codecov.io/gh/executablebooks/mdformat-obsidian
  -->
 
-An [mdformat](https://github.com/executablebooks/mdformat) plugin for [Obsidian Flavored Markdown](https://help.obsidian.md/Editing+and+formatting/Obsidian+Flavored+Markdown). This plugin directly supports [Callouts](https://help.obsidian.md/Editing+and+formatting/Callouts), inline footnotes, task lists with custom markers, and dollar math. See the test directory for supported formats.
+An [mdformat](https://github.com/executablebooks/mdformat) plugin for [Obsidian Flavored Markdown](https://help.obsidian.md/Editing+and+formatting/Obsidian+Flavored+Markdown).
+
+## Features
+
+- **[Callouts](https://help.obsidian.md/Editing+and+formatting/Callouts)** - Alert-style blocks with custom titles and folding
+  - Supports all standard callout types (note, tip, warning, etc.)
+  - Custom callout types with any identifier
+  - Foldable callouts with `-` or `+` indicators
+  - Nested callouts
+  - Case-insensitive type matching (normalized to uppercase for compatibility)
+- **Inline Footnotes** - Obsidian's `^[inline footnote]` syntax
+- **Task Lists** - Extended checklist markers beyond `[x]` and `[ ]`
+  - Supports `[?]`, `[/]`, `[-]`, and other custom markers
+  - Preserves marker style during formatting
+- **Dollar Math** - LaTeX math with `$...$` and `$$...$$` delimiters
+  - Inline math: `$E=mc^2$`
+  - Block math: `$$\n...\n$$`
 
 > [!NOTE]
-> The format for [GitHub Alerts](https://github.com/kyleking/mdformat-gfm-alerts) differs slightly from Obsidian, so they are not fully compatible. Obsidian supports folding, custom titles, and is case insensitive. To improve interoperability, this package makes the stylistic choice of capitalizing the text within `[!...]`.
+> The format for [GitHub Alerts](https://github.com/kyleking/mdformat-gfm-alerts) differs slightly from Obsidian callouts. Obsidian supports folding, custom titles, and is case-insensitive. For improved interoperability, this package normalizes callout types to uppercase (e.g., `[!tip]` → `[!TIP]`).
 
 ## `mdformat` Usage
 
@@ -51,11 +67,10 @@ pipx inject mdformat mdformat-obsidian
 
 ## HTML Rendering
 
-To generate HTML output, `obsidian_plugin` can be imported from `mdit_plugins`. For more guidance on `MarkdownIt`, see the docs: <https://markdown-it-py.readthedocs.io/en/latest/using.html#the-parser>
+To generate HTML output, use `obsidian_plugin` from `mdit_plugins`. This combines all Obsidian-flavored markdown features (callouts, footnotes, task lists, math). For more details, see the [markdown-it-py documentation](https://markdown-it-py.readthedocs.io/en/latest/using.html#the-parser).
 
 ```py
 from markdown_it import MarkdownIt
-
 from mdformat_obsidian.mdit_plugins import obsidian_plugin
 
 md = MarkdownIt()
@@ -63,7 +78,7 @@ md.use(obsidian_plugin)
 
 text = "> [!tip] Callouts can have custom titles\n> Like this one."
 md.render(text)
-# <blockquote>
+# <div>
 # <div data-callout-metadata="" data-callout-fold="" data-callout="tip" class="callout">
 # <div class="callout-title">
 # <div class="callout-title-inner">Callouts can have custom titles</div>
@@ -72,11 +87,16 @@ md.render(text)
 # <p>Like this one.</p>
 # </div>
 # </div>
-# </blockquote>
+# </div>
 ```
 
-> [!WARNING]
-> The outer `<blockquote>` tag is preserved to maintain compatibility with standard Markdown parsers. For full accessibility, you may want to replace this with a `<div>` in post-processing, as the `>` blockquote syntax is being repurposed for callouts.
+**Accessibility Note:** For improved semantics, callouts are rendered as `<div>` elements rather than `<blockquote>`. The `>` syntax is repurposed for callouts (not quotations), so using div elements better represents the content structure. See [discussion on GitHub](https://github.com/orgs/community/discussions/16925#discussioncomment-8729846).
+
+## Caveats
+
+- **LaTeX Math**: Direct `\begin{...}` LaTeX environments are not supported. Use dollar math syntax (`$...$` or `$$...$$`) instead.
+- **HTML Output Only**: The HTML rendering features are designed for programmatic HTML generation. For markdown-to-markdown formatting (the primary mdformat use case), these renderers are not invoked.
+- **GitHub Compatibility**: While callouts work in both Obsidian and GitHub, subtle formatting differences exist. This plugin prioritizes Obsidian compatibility.
 
 ## Contributing
 

--- a/tests/format/fixtures/dollar_math.md
+++ b/tests/format/fixtures/dollar_math.md
@@ -57,7 +57,7 @@ $$ (mymath2)
 The equation {eq}`mymath2` is also a quadratic equation.
 .
 
-(TODO: Unsupported) LaTeX Math (https://myst-parser.readthedocs.io/en/latest/syntax/math.html#direct-latex-math)
+(Unsupported) LaTeX Math (https://myst-parser.readthedocs.io/en/latest/syntax/math.html#direct-latex-math)
 .
 \begin{gather*}
 a_1=b_1+c_1\\

--- a/tests/format/fixtures/obsidian_callouts.md
+++ b/tests/format/fixtures/obsidian_callouts.md
@@ -70,3 +70,116 @@ Don't crash on incomplete alert (https://github.com/KyleKing/mdformat-obsidian/i
 
 > [!NOTE]
 .
+
+Callout with Code Block
+.
+> [!tip] Code in Callouts
+> You can include code:
+>
+> ```python
+> def hello():
+>     print("world")
+> ```
+.
+> [!TIP] Code in Callouts
+> You can include code:
+>
+> ```python
+> def hello():
+>     print("world")
+> ```
+.
+
+Callout with Lists
+.
+> [!note] Lists work too
+> - Item 1
+> - Item 2
+>   - Nested item
+> - Item 3
+.
+> [!NOTE] Lists work too
+> - Item 1
+> - Item 2
+>   - Nested item
+> - Item 3
+.
+
+Callout with Multiple Paragraphs
+.
+> [!warning] Multiple paragraphs
+> First paragraph with some text.
+>
+> Second paragraph with more content.
+>
+> Third paragraph for good measure.
+.
+> [!WARNING] Multiple paragraphs
+> First paragraph with some text.
+>
+> Second paragraph with more content.
+>
+> Third paragraph for good measure.
+.
+
+Empty Callout Content
+.
+> [!info]
+.
+> [!INFO]
+.
+
+Callout Types - All Standard Types
+.
+> [!note] Note callout
+
+> [!abstract] Abstract/Summary callout
+
+> [!info] Info callout
+
+> [!todo] Todo callout
+
+> [!tip] Tip/Hint callout
+
+> [!success] Success/Check callout
+
+> [!question] Question/Help callout
+
+> [!warning] Warning/Caution callout
+
+> [!failure] Failure/Fail callout
+
+> [!danger] Danger/Error callout
+
+> [!bug] Bug callout
+
+> [!example] Example callout
+
+> [!quote] Quote/Cite callout
+.
+> [!NOTE] Note callout
+
+> [!ABSTRACT] Abstract/Summary callout
+
+> [!INFO] Info callout
+
+> [!TODO] Todo callout
+
+> [!TIP] Tip/Hint callout
+
+> [!SUCCESS] Success/Check callout
+
+> [!QUESTION] Question/Help callout
+
+> [!WARNING] Warning/Caution callout
+
+> [!FAILURE] Failure/Fail callout
+
+> [!DANGER] Danger/Error callout
+
+> [!BUG] Bug callout
+
+> [!EXAMPLE] Example callout
+
+> [!QUOTE] Quote/Cite callout
+.

--- a/tests/render/fixtures/obsidian_callouts.md
+++ b/tests/render/fixtures/obsidian_callouts.md
@@ -66,3 +66,70 @@ Nested Callouts
 </div>
 </div>
 .
+
+Callout with Code Block
+.
+> [!tip] Code in Callouts
+> You can include code:
+>
+> ```python
+> def hello():
+>     print("world")
+> ```
+.
+<div>
+<div data-callout-metadata="" data-callout-fold="" data-callout="tip" class="callout">
+<div class="callout-title">
+<div class="callout-title-inner">Code in Callouts</div>
+</div>
+<div class="callout-content">
+<p>You can include code:</p>
+<pre><code class="language-python">def hello():
+    print(&quot;world&quot;)
+</code></pre>
+</div>
+</div>
+</div>
+.
+
+Callout with Lists
+.
+> [!note] Lists work too
+> - Item 1
+> - Item 2
+>   - Nested item
+> - Item 3
+.
+<div>
+<div data-callout-metadata="" data-callout-fold="" data-callout="note" class="callout">
+<div class="callout-title">
+<div class="callout-title-inner">Lists work too</div>
+</div>
+<div class="callout-content">
+<ul>
+<li>Item 1</li>
+<li>Item 2
+<ul>
+<li>Nested item</li>
+</ul>
+</li>
+<li>Item 3</li>
+</ul>
+</div>
+</div>
+</div>
+.
+
+Empty Callout
+.
+> [!info]
+.
+<div>
+<div data-callout-metadata="" data-callout-fold="" data-callout="info" class="callout">
+<div class="callout-title">
+<div class="callout-title-inner"></div>
+</div>
+<div class="callout-content"></div>
+</div>
+</div>
+.

--- a/tests/render/fixtures/obsidian_callouts.md
+++ b/tests/render/fixtures/obsidian_callouts.md
@@ -3,7 +3,7 @@ Custom Titles
 > [!tip] Callouts can have custom titles
 > Like this one.
 .
-<blockquote>
+<div>
 <div data-callout-metadata="" data-callout-fold="" data-callout="tip" class="callout">
 <div class="callout-title">
 <div class="callout-title-inner">Callouts can have custom titles</div>
@@ -12,7 +12,7 @@ Custom Titles
 <p>Like this one.</p>
 </div>
 </div>
-</blockquote>
+</div>
 .
 
 Foldable Callouts
@@ -20,7 +20,7 @@ Foldable Callouts
 > [!faq]- Are callouts foldable?
 > Yes! In a foldable callout, the contents are hidden when the callout is collapsed.
 .
-<blockquote>
+<div>
 <div data-callout-metadata="" data-callout-fold="-" data-callout="faq" class="callout is-collapsible is-collapsed">
 <div class="callout-title">
 <div class="callout-title-inner">Are callouts foldable?</div>
@@ -30,7 +30,7 @@ Foldable Callouts
 <p>Yes! In a foldable callout, the contents are hidden when the callout is collapsed.</p>
 </div>
 </div>
-</blockquote>
+</div>
 .
 
 Nested Callouts
@@ -39,30 +39,30 @@ Nested Callouts
 > > [!todo] Yes!, they can.
 > > > [!example]  You can even use multiple layers of nesting.
 .
-<blockquote>
+<div>
 <div data-callout-metadata="" data-callout-fold="" data-callout="question" class="callout">
 <div class="callout-title">
 <div class="callout-title-inner">Can callouts be nested?</div>
 </div>
 <div class="callout-content">
-<blockquote>
+<div>
 <div data-callout-metadata="" data-callout-fold="" data-callout="todo" class="callout">
 <div class="callout-title">
 <div class="callout-title-inner">Yes!, they can.</div>
 </div>
 <div class="callout-content">
-<blockquote>
+<div>
 <div data-callout-metadata="" data-callout-fold="" data-callout="example" class="callout">
 <div class="callout-title">
 <div class="callout-title-inner">You can even use multiple layers of nesting.</div>
 </div>
 <div class="callout-content"></div>
 </div>
-</blockquote>
 </div>
 </div>
-</blockquote>
 </div>
 </div>
-</blockquote>
+</div>
+</div>
+</div>
 .


### PR DESCRIPTION
Implements post-processing suggestion to render callouts within semantic `<div>` tags instead of `<blockquote>` for improved accessibility. The `>` syntax is being repurposed for callouts rather than quotations.

Implementation details:

- Override blockquote_open/close HTML renderers to detect callouts
- Use div tags when blockquote contains obsidian_callout
- Preserve markdown tokens as blockquote for mdformat compatibility
- Extract render functions to module level (ruff C901 compliance)
- Add complete type annotations (RendererHTML, OptionsDict, EnvType)

Changes:

- Updated all HTML test fixtures from `<blockquote>` to `<div>`
- Nested callouts now use div wrappers throughout
- mdformat still processes callouts correctly (tokens unchanged)

Tests: All 20 tests passing
Ref: https://github.com/orgs/community/discussions/16925#discussioncomment-8729846